### PR TITLE
TMDM-11327 Build org.talend.mdm.core.enterprise : datastewardship-client repository is wrong

### DIFF
--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -66,10 +66,33 @@
         </repository>
         <repository>
             <id>releases</id>
+            <url>https://artifacts-zl.talend.com/nexus/content/repositories/releases</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-            <url>https://artifacts-zl.talend.com/nexus/content/repositories/releases</url>
+        </repository>
+         <repository>
+            <id>snapshots</id>
+            <url>https://artifacts-zl.talend.com/nexus/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>talend-tpsvc</id>
+            <url>https://artifacts-zl.talend.com/nexus/content/repositories/tpsvc</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
         <repository>
             <id>thirdparty-releases</id>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
Will try do download datastewardship-client from TalendOpenSourceSnapshot, but it is not there.

**What is the new behavior?**
Add repository of snapshots to pom.xml to make download the jar from it.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
