### PR TITLE
TMDM-11636 blackduck scans integration

### DIFF
--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -429,6 +429,20 @@
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.7.5.201505241946</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.talend.tools</groupId>
+                    <artifactId>talend-tools-maven-plugin</artifactId>
+                    <version>1.0.3</version>
+                    <configuration>
+                        <atTheEnd>false</atTheEnd>
+                        <serverId>blackduck-mdm</serverId>
+                        <blackduckUrl>https://blackduck.talend.com</blackduckUrl>
+                        <blackduckName>Talend MDM (TMDM)</blackduckName>
+                        <systemVariables>
+                            <detect.output.path>$rootProject/.blackduck</detect.output.path>
+                        </systemVariables>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -1407,6 +1421,19 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.talend.tools</groupId>
+                        <artifactId>talend-tools-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>hub-detect</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>hub-detect</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -1481,6 +1508,33 @@
                                 <phase>verify</phase>
                                 <goals>
                                     <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- For local build -->
+            <id>blackduck</id>
+            <activation>
+                <property>
+                    <name>mdm.build.blackduck</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.talend.tools</groupId>
+                        <artifactId>talend-tools-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>hub-detect</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>hub-detect</goal>
                                 </goals>
                             </execution>
                         </executions>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
No blackduck scan at all

**What is the new behavior?**
- Official build will enable blackduck scan automatically
- Local build should provide parameter `mdm.build.blackduck=true` to enable blackduck scan, naming policy same as the one for code coverage `mdm.build.coverage`


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

  