### PR TITLE
TMDM-12742 Isolation UserQuery into new module

### DIFF
--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -507,6 +507,11 @@
             </dependency>
             <dependency>
                 <groupId>org.talend.mdm</groupId>
+                <artifactId>org.talend.mdm.query</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.talend.mdm</groupId>
                 <artifactId>org.talend.mdm.core</artifactId>
                 <version>${project.version}</version>
                 <classifier>jaas</classifier>


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)

https://jira.talendforge.org/browse/TMDM-12742

The class QueryParser is able to build an Expression from a JSON content (that is for most of the cases a Select clause, except for native queries).

But if one wants to use UserQueryBuilder to build a request that allows easy interaction with MDM REST API, the code is isolated in the MDM Server.

**What is the new behavior?**

The user query construction is isolated into a new module org.talend.mdm.query to allow it to be reused from an external perspective.

On this project, just add the new module Maven build.

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
CAUTION :: 
This JIRA is related to https://github.com/Talend/tmdm-server-ee/pull/705 and https://github.com/Talend/tmdm-server-ee/pull/437

Jenkins build : http://192.168.31.210:8080/view/Master/job/Master_03_TMDMEE_FOR-JIRA/1733/