### PR TITLE
TMDM-12558 JAX-RS libraries conflicting

### DIFF
--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -24,6 +24,7 @@
         <gwt.gxt.version>2.2.5-gwt22</gwt.gxt.version>
         <gwt.dnd.version>3.1.2</gwt.dnd.version>
 
+        <apache.httpcomponents.version>4.3.6</apache.httpcomponents.version>
         <spring.version>4.3.7.RELEASE</spring.version>
         <spring.security.version>4.2.2.RELEASE</spring.security.version>
         <cxf.version>3.1.12</cxf.version>
@@ -1030,12 +1031,17 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.3.4</version>
+                <version>${apache.httpcomponents.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>fluent-hc</artifactId>
-                <version>4.3.4</version>
+                <version>${apache.httpcomponents.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpmime</artifactId>
+                <version>${apache.httpcomponents.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.directwebremoting</groupId>

--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -851,11 +851,6 @@
                 <version>1.1</version>
             </dependency>
             <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>jsr311-api</artifactId>
-                <version>1.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>1.6.1</version>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-12558
**What is the current behavior?** (You should also link to an open issue here)
We have jsr311-api-1.0.jar and javax.ws.rs-api-2.0.1.jar in class path,there is a conflict in class 'javax.ws.rs.core.Response'.We can not call the right class in Linux environment.


**What is the new behavior?**
In order to prevent packaging multiple jars for the same classes,we remove dependency of jsr311-api-1.0.jar,we don't have jsr311-api-1.0.jar in mdm server any more.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
