### PR TITLE
TMDM-12558 JAX-RS libraries conflicting.

### DIFF
--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -845,11 +845,6 @@
                 <version>1.1</version>
             </dependency>
             <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>jsr311-api</artifactId>
-                <version>1.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>1.6.1</version>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-12558
**What is the current behavior?** (You should also link to an open issue here)
We have jsr311-api-1.0.jar and javax.ws.rs-api-2.0.1.jar in class path,there is a conflict in class 'javax.ws.rs.core.Response'.We can not call the right class in Linux environment.


**What is the new behavior?**
In order to prevent packaging multiple jars for the same classes,we remove dependency of jsr311-api-1.0.jar,we don't have jsr311-api-1.0.jar in mdm server any more.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
