### PR TITLE
TMDM-12592 Java 11 support

### DIFF
--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -27,7 +27,7 @@
         <apache.httpcomponents.version>4.3.6</apache.httpcomponents.version>
         <spring.version>4.3.7.RELEASE</spring.version>
         <spring.security.version>4.2.2.RELEASE</spring.security.version>
-        <cxf.version>3.1.12</cxf.version>
+        <cxf.version>3.3.0</cxf.version>
         <powermock.version>1.4.12</powermock.version>
         <hibernate.search.version>5.0.1.Final</hibernate.search.version>
 
@@ -44,6 +44,7 @@
         <xalan.version>2.7.1</xalan.version>
         <saxon.version>9.0.0.8</saxon.version>
         <audit.version>0.20.0</audit.version>
+        <jaxb.version>2.3.0</jaxb.version>
     </properties>
     <repositories>
         <repository>
@@ -154,7 +155,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.5.1</version>
+                    <version>3.8.0</version>
                     <configuration>
                         <source>1.8</source>
                         <target>1.8</target>
@@ -877,6 +878,27 @@
                 <groupId>javax.transaction</groupId>
                 <artifactId>jta</artifactId>
                 <version>1.1</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-core</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.ws</groupId>
+                <artifactId>jaxws-ri</artifactId>
+                <version>2.3.0</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -27,7 +27,7 @@
         <apache.httpcomponents.version>4.3.6</apache.httpcomponents.version>
         <spring.version>4.3.7.RELEASE</spring.version>
         <spring.security.version>4.2.2.RELEASE</spring.security.version>
-        <cxf.version>3.3.0</cxf.version>
+        <cxf.version>3.1.12</cxf.version>
         <powermock.version>1.4.12</powermock.version>
         <hibernate.search.version>5.0.1.Final</hibernate.search.version>
 
@@ -44,7 +44,6 @@
         <xalan.version>2.7.1</xalan.version>
         <saxon.version>9.0.0.8</saxon.version>
         <audit.version>0.20.0</audit.version>
-        <jaxb.version>2.3.0</jaxb.version>
     </properties>
     <repositories>
         <repository>
@@ -880,25 +879,9 @@
                 <version>1.1</version>
             </dependency>
             <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>${jaxb.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-core</artifactId>
-                <version>${jaxb.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-impl</artifactId>
-                <version>${jaxb.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.xml.ws</groupId>
-                <artifactId>jaxws-ri</artifactId>
-                <version>2.3.0</version>
-                <type>pom</type>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>2.3.2</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -881,7 +881,7 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
-                <version>2.3.2</version>
+                <version>2.3.0</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -890,6 +890,11 @@
                 <version>1.2.0</version>
             </dependency>
             <dependency>
+                <groupId>javax.activation</groupId>
+                <artifactId>activation</artifactId>
+                <version>1.1</version>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>1.6.1</version>

--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -883,7 +883,12 @@
                 <artifactId>jaxws-ri</artifactId>
                 <version>2.3.0</version>
                 <type>pom</type>
-            </dependency>            
+            </dependency>
+            <dependency>
+                <groupId>javax.activation</groupId>
+                <artifactId>javax.activation-api</artifactId>
+                <version>1.2.0</version>
+            </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>

--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -879,10 +879,11 @@
                 <version>1.1</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.jaxb</groupId>
-                <artifactId>jaxb-runtime</artifactId>
+                <groupId>com.sun.xml.ws</groupId>
+                <artifactId>jaxws-ri</artifactId>
                 <version>2.3.0</version>
-            </dependency>
+                <type>pom</type>
+            </dependency>            
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)
https://jira.talendforge.org/browse/TMDM-12592
MDM server couldn't be deployed in JRE 11.

**What is the new behavior?**

This is to support Java 11 runtime for MDM server, so that MDM can be compiled in JDK 8 and deployed in JRE 8 or JRE 11.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
