### PR TITLE
TMDM-13202 FK : render in main tab in MetadataRepository

### DIFF
--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/ReferenceFieldMetadata.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/ReferenceFieldMetadata.java
@@ -387,7 +387,8 @@ public class ReferenceFieldMetadata extends MetadataExtensions implements FieldM
                 foreignKeyFilter,
                 visibilityRule,
                 noAddRoles,
-                noRemoveRoles);
+                noRemoveRoles,
+                isFKMainRender);
         copy.localeToLabel.putAll(localeToLabel);
         copy.localeToDescription.putAll(localeToDescription);
         if (dataMap != null) {


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-13202

**What is the current behavior?** (You should also link to an open issue here)
1. The Reference field in Container, the value of  **isFKMainRender** is not correct.


**What is the new behavior?**
1. Reference field in Container, copy from the first instantiation, set **isFKMainRender** value when copy.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
