### PR TITLE
TPS-3569 [7.1.1] Talend MDM timeout cannot be increased with IAM enabled (TMDM-12908)

### DIFF
--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -1209,7 +1209,7 @@
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
-                <version>3.0.1</version>
+                <version>4.0.1</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Backport
- TMDM-12908 Talend MDM timeout cannot be increased with IAM enabled