### PR TITLE
TMDM-14289 tMDMRollback somtimes let transactions "opened" 

### DIFF
--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/core/MDMConfiguration.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/core/MDMConfiguration.java
@@ -226,11 +226,13 @@ public final class MDMConfiguration {
         }
     }
 
-    /*
-     * For transaction concurrency control, will affect SOAP API and Transaction Service, 
-     * see: com.amalto.core.delegator.IXtentisWSDelegator.partialPutItem, putItem,
-     *  putItemArray, putItemWithReport, putItemWithCustomReport, putItemWithReportArray,
-     *  and com.amalto.core.storage.transaction.TransactionService.rollback, commit
+    /**
+     * For transaction concurrency control, will affect SOAP API and Transaction Service.
+     * @see
+     * IXtentisWSDelegator#partialPutItem(), IXtentisWSDelegator#putItem(),
+     * IXtentisWSDelegator#putItemArray(), IXtentisWSDelegator#putItemWithReport(),
+     * IXtentisWSDelegator#putItemWithCustomReport(), IXtentisWSDelegator#putItemWithReportArray(),
+     * TransactionService#rollback(), TransactionService#commit()}
      */
     public static int getTransactionConcurrent() {
         String config = MDMConfiguration.getConfiguration().getProperty(TRANSACTION_REQUESTS);

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/core/MDMConfiguration.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/core/MDMConfiguration.java
@@ -226,6 +226,12 @@ public final class MDMConfiguration {
         }
     }
 
+    /*
+     * For transaction concurrency control, will affect SOAP API and Transaction Service, 
+     * see: com.amalto.core.delegator.IXtentisWSDelegator.partialPutItem, putItem,
+     *  putItemArray, putItemWithReport, putItemWithCustomReport, putItemWithReportArray,
+     *  and com.amalto.core.storage.transaction.TransactionService.rollback, commit
+     */
     public static int getTransactionConcurrent() {
         String config = MDMConfiguration.getConfiguration().getProperty(TRANSACTION_REQUESTS);
         if (config != null) {

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/core/MDMConfiguration.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/core/MDMConfiguration.java
@@ -13,6 +13,7 @@ package org.talend.mdm.commmon.util.core;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.configuration.ConfigurationConverter;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -65,6 +66,10 @@ public final class MDMConfiguration {
     public static final String SCIM_USER = "scim.username";
 
     public static final String SCIM_PASSWORD = "scim.password";
+
+    public static final String TRANSACTION_REQUESTS = "transaction.concurrent.requests";
+
+    public static final String TRANSACTION_WAIT_MILLISECONDS = "transaction.concurrent.wait.milliseconds";
 
     private static final Logger LOGGER = Logger.getLogger(MDMConfiguration.class);
 
@@ -222,4 +227,13 @@ public final class MDMConfiguration {
         }
     }
 
+    public static String getTransactionConcurrentRequests() {
+        Properties properties = MDMConfiguration.getConfiguration();
+        return properties.getProperty(TRANSACTION_REQUESTS);
+    }
+
+    public static String getTransactionConcurrentWaitMilliseconds() {
+        Properties properties = MDMConfiguration.getConfiguration();
+        return properties.getProperty(TRANSACTION_WAIT_MILLISECONDS);
+    }
 }

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/core/MDMConfiguration.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/core/MDMConfiguration.java
@@ -66,7 +66,7 @@ public final class MDMConfiguration {
 
     public static final String SCIM_PASSWORD = "scim.password";
 
-    public static final String TRANSACTION_REQUESTS = "transaction.concurrent.requests";
+    public static final String TRANSACTION_MAX_REQUESTS = "transaction.concurrent.max.requests";
 
     public static final String TRANSACTION_WAIT_MILLISECONDS = "transaction.concurrent.wait.milliseconds";
 
@@ -234,14 +234,14 @@ public final class MDMConfiguration {
      * IXtentisWSDelegator#putItemWithCustomReport(), IXtentisWSDelegator#putItemWithReportArray(),
      * TransactionService#rollback(), TransactionService#commit()}
      */
-    public static int getTransactionConcurrent() {
-        String config = MDMConfiguration.getConfiguration().getProperty(TRANSACTION_REQUESTS);
+    public static int getTransactionMaxRequests() {
+        String config = MDMConfiguration.getConfiguration().getProperty(TRANSACTION_MAX_REQUESTS);
         if (config != null) {
             try {
                 return Integer.valueOf(config);
             } catch (Exception e) {
                 if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("Failed to read configuration: " + TRANSACTION_REQUESTS, e);
+                    LOGGER.debug("Failed to read configuration: " + TRANSACTION_MAX_REQUESTS, e);
                 }
                 return 0;
             }

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/core/MDMConfiguration.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/core/MDMConfiguration.java
@@ -13,7 +13,6 @@ package org.talend.mdm.commmon.util.core;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.configuration.ConfigurationConverter;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -227,13 +226,33 @@ public final class MDMConfiguration {
         }
     }
 
-    public static String getTransactionConcurrentRequests() {
-        Properties properties = MDMConfiguration.getConfiguration();
-        return properties.getProperty(TRANSACTION_REQUESTS);
+    public static int getTransactionConcurrent() {
+        String config = MDMConfiguration.getConfiguration().getProperty(TRANSACTION_REQUESTS);
+        if (config != null) {
+            try {
+                return Integer.valueOf(config);
+            } catch (Exception e) {
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Failed to read configuration: " + TRANSACTION_REQUESTS, e);
+                }
+                return 0;
+            }
+        }
+        return 0;
     }
 
-    public static String getTransactionConcurrentWaitMilliseconds() {
-        Properties properties = MDMConfiguration.getConfiguration();
-        return properties.getProperty(TRANSACTION_WAIT_MILLISECONDS);
+    public static long getTransactionWaitMilliseconds() {
+        String config = MDMConfiguration.getConfiguration().getProperty(TRANSACTION_WAIT_MILLISECONDS);
+        if (config != null) {
+            try {
+                return Long.valueOf(config);
+            } catch (Exception e) {
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Failed to read configuration: " + TRANSACTION_WAIT_MILLISECONDS, e);
+                }
+                return 10L;
+            }
+        }
+        return 10L;
     }
 }


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14289
**What is the current behavior?** (You should also link to an open issue here)

A job that fails (exception) and calls tMDMRollback sometimes let a transaction "opened" (not commited , not rollbacked). It was found that storage begin may not completed with storage commit or storage rollback in a request if there are many requests from a loop Studio Job.

**What is the new behavior?**

Added request number limit, this will ensure that a request can complete the whole process of transaction.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
