### PR TITLE
TMDM-14192 AUTO_INCREMENT value for NOT Primary Key reset to 0 after MDM restart 

### DIFF
--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -27,7 +27,7 @@
         <spring.version>4.3.7.RELEASE</spring.version>
         <spring.security.version>4.2.2.RELEASE</spring.security.version>
         <cxf.version>3.1.12</cxf.version>
-        <powermock.version>1.4.12</powermock.version>
+        <powermock.version>1.7.4</powermock.version>
         <hibernate.search.version>5.0.1.Final</hibernate.search.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -455,7 +455,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.8.2</version>
+                <version>4.13</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-14192
**What is the current behavior?** (You should also link to an open issue here)
Junit  and powermock version are low.


**What is the new behavior?**
change the Junit version from 4.8.2 to 4.13
change the powermock version from 1.4.12 to 1.7.4


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
