### PR TITLE
Revert "TMDM-14128 Update version of org.talend.utils to release version 7.3.1 before release"

### DIFF
--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -642,7 +642,7 @@
             <dependency>
                 <groupId>org.talend</groupId>
                 <artifactId>org.talend.utils</artifactId>
-                <version>${project.version}</version>
+                <version>7.3.1-SNAPSHOT</version>
                 <exclusions>
                     <exclusion>
                         <groupId>log4j</groupId>


### PR DESCRIPTION
Reverts Talend/tmdm-common#168
org.talend.utils would be built after the MDM , so dependency wouldn't be found