### PR TITLE
TMDM-14649 - Update Commons Collections to 3.2.2

### DIFF
--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -1229,7 +1229,7 @@
             <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
-                <version>3.2.1</version>
+                <version>3.2.2</version>
             </dependency>
             <dependency>
                 <groupId>bsh</groupId>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14649
This task is to update Commons Collections 3.2.1 to 3.2.2 to fix a high level CVE reported by Veracode.