### PR TITLE
TMDM-14653 - Update Commons BeanUtils to 1.9.4

### DIFF
--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -1244,7 +1244,7 @@
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
-                <version>1.6.1</version>
+                <version>1.9.4</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.jra</groupId>


### PR DESCRIPTION
Veracode is reporting a high level CVE issue associated with BeanUtils 1.6.1. Instead we should update to 1.9.4