### PR TITLE
TMDM-14656 - Update XercesImpl to 2.12.0

### DIFF
--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -938,7 +938,7 @@
             <dependency>
                 <groupId>xml-apis</groupId>
                 <artifactId>xml-apis</artifactId>
-                <version>1.0.b2</version>
+                <version>1.4.01</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -1298,7 +1298,7 @@
             <dependency>
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
-                <version>2.9.1</version>
+                <version>2.12.0</version>
             </dependency>
             <dependency>
                 <groupId>javax.validation</groupId>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14656

Veracode is detecting a high level CVE regarding XercesImpl 2.6.1. This task is to update to 2.12.0.