### PR TITLE
TMDM-14657 - Update Spring Security to 4.2.13

### DIFF
--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -26,7 +26,7 @@
 
         <apache.httpcomponents.version>4.5.10</apache.httpcomponents.version>
         <spring.version>4.3.23.RELEASE</spring.version>
-        <spring.security.version>4.2.2.RELEASE</spring.security.version>
+        <spring.security.version>4.2.13.RELEASE</spring.security.version>
         <cxf.version>3.3.4</cxf.version>
         <powermock.version>1.7.4</powermock.version>
         <hibernate.search.version>5.0.1.Final</hibernate.search.version>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14657

This task is to update Spring Security from 4.2.2 to 4.2.13 to pick up a fix for a high level CVE reported by Veracode.