### PR TITLE
TMDM-14588 Update CXF to 3.3.6 due to CVE-2020-1954

### DIFF
--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -27,7 +27,7 @@
         <apache.httpcomponents.version>4.5.10</apache.httpcomponents.version>
         <spring.version>4.3.23.RELEASE</spring.version>
         <spring.security.version>4.2.13.RELEASE</spring.security.version>
-        <cxf.version>3.3.4</cxf.version>
+        <cxf.version>3.3.6</cxf.version>
         <powermock.version>1.7.4</powermock.version>
         <hibernate.search.version>5.0.1.Final</hibernate.search.version>
 


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14588

**What is the current behavior?** (You should also link to an open issue here)

Apache CXF version 3.3.4 in ./tmdm-common/org.talend.mdm.base/pom.xml has issue of CVE-2020-1954

**What is the new behavior?**

Update Apache CXF to 3.3.6 in ./tmdm-common/org.talend.mdm.base/pom.xml

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
