### PR TITLE
TMDM-14697 [CVE] - Update Log4J 1.x

### DIFF
--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/ComplexTypeMetadataImpl.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/ComplexTypeMetadataImpl.java
@@ -25,7 +25,8 @@ import java.util.StringTokenizer;
 
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.talend.mdm.commmon.metadata.validation.ValidationFactory;
 import org.talend.mdm.commmon.metadata.validation.ValidationRule;
 
@@ -34,7 +35,7 @@ import org.talend.mdm.commmon.metadata.validation.ValidationRule;
  */
 public class ComplexTypeMetadataImpl extends MetadataExtensions implements ComplexTypeMetadata {
 
-    private static final Logger LOGGER = Logger.getLogger(ComplexTypeMetadataImpl.class);
+    private static final Logger LOGGER = LogManager.getLogger(ComplexTypeMetadataImpl.class);
 
     private final String nameSpace;
 

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/ConsoleDumpMetadataVisitor.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/ConsoleDumpMetadataVisitor.java
@@ -11,7 +11,8 @@
 
 package org.talend.mdm.commmon.metadata;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/DefaultMetadataVisitor.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/DefaultMetadataVisitor.java
@@ -15,14 +15,15 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * Default visitor for data model classes in package org.talend.mdm.commmon.metadata.
  */
 public class DefaultMetadataVisitor<T> implements MetadataVisitor<T> {
 
-    private static final Logger LOGGER = Logger.getLogger(DefaultMetadataVisitor.class);
+    private static final Logger LOGGER = LogManager.getLogger(DefaultMetadataVisitor.class);
 
     protected static boolean isDatabaseMandatory(FieldMetadata field, TypeMetadata declaringType) {
         boolean isDatabaseMandatory = field.isMandatory() && declaringType.isInstantiable();

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/DefaultValidationHandler.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/DefaultValidationHandler.java
@@ -12,14 +12,15 @@
 package org.talend.mdm.commmon.metadata;
 
 import org.apache.commons.collections.map.MultiKeyMap;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Element;
 
 import java.util.*;
 
 public class DefaultValidationHandler implements ValidationHandler {
 
-    private static final Logger LOGGER = Logger.getLogger(DefaultValidationHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(DefaultValidationHandler.class);
 
     private final Map<ValidationError, MultiKeyMap> errors = new HashMap<ValidationError, MultiKeyMap>();
 

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/MetadataRepository.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/MetadataRepository.java
@@ -29,7 +29,8 @@ import javax.xml.XMLConstants;
 
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xsd.XSDAnnotation;
@@ -139,7 +140,7 @@ public class MetadataRepository implements MetadataVisitable, XSDVisitor, Serial
             DEFAULT_VALUE, DEFAULT_VALUE_RULE, MIN_OCCURS, MAX_OCCURS, ENUMERATION_LIST, MAX_EXCLUSIVE, MIN_EXCLUSIVE, PATTERN,
             MAX_INCLUSIVE, MIN_INCLUSIVE, VALIDATION_MARKER, VALIDATION_PERMISSION_MARKER };
 
-    private static final Logger LOGGER = Logger.getLogger(MetadataRepository.class);
+    private static final Logger LOGGER = LogManager.getLogger(MetadataRepository.class);
 
     private final Map<XSDTypeDefinition, List<ComplexTypeMetadata>> entityTypeUsage = new HashMap<XSDTypeDefinition, List<ComplexTypeMetadata>>() {
 

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/MetadataUtils.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/MetadataUtils.java
@@ -27,11 +27,12 @@ import javax.xml.XMLConstants;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class MetadataUtils {
 
-    private static final Logger LOGGER = Logger.getLogger(MetadataUtils.class);
+    private static final Logger LOGGER = LogManager.getLogger(MetadataUtils.class);
 
     private MetadataUtils() {
     }

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/compare/Compare.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/compare/Compare.java
@@ -23,7 +23,8 @@ import java.util.Set;
 import java.util.Stack;
 
 import org.apache.commons.lang.ObjectUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
 import org.talend.mdm.commmon.metadata.ContainedComplexTypeMetadata;
 import org.talend.mdm.commmon.metadata.ContainedTypeFieldMetadata;
@@ -41,7 +42,7 @@ import org.talend.mdm.commmon.util.core.CommonUtil;
 
 public class Compare {
 
-    private static final Logger LOGGER = Logger.getLogger(Compare.class);
+    private static final Logger LOGGER = LogManager.getLogger(Compare.class);
 
     /**
      * Compare two {@link org.talend.mdm.commmon.metadata.MetadataRepository repositories} and return the differences

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/validation/CircularComplexTypeValidationRule.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/validation/CircularComplexTypeValidationRule.java
@@ -12,7 +12,8 @@ package org.talend.mdm.commmon.metadata.validation;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
 import org.talend.mdm.commmon.metadata.ContainedComplexTypeMetadata;
 import org.talend.mdm.commmon.metadata.DefaultMetadataVisitor;
@@ -29,7 +30,7 @@ import org.w3c.dom.Element;
  */
 public class CircularComplexTypeValidationRule implements ValidationRule {
 
-    private static final Logger LOGGER = Logger.getLogger(CircularComplexTypeValidationRule.class);
+    private static final Logger LOGGER = LogManager.getLogger(CircularComplexTypeValidationRule.class);
 
     private final MetadataRepository repository;
 

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/validation/XSDAttributeValidationRule.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/validation/XSDAttributeValidationRule.java
@@ -20,7 +20,8 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.eclipse.xsd.util.XSDParser;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
 import org.talend.mdm.commmon.metadata.MetadataRepository;
@@ -35,7 +36,7 @@ import org.w3c.dom.NodeList;
  */
 class XSDAttributeValidationRule implements ValidationRule {
 
-    private static final Logger LOGGER = Logger.getLogger(XSDAttributeValidationRule.class);
+    private static final Logger LOGGER = LogManager.getLogger(XSDAttributeValidationRule.class);
 
     private final ComplexTypeMetadata type;
 

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/core/EncryptUtil.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/core/EncryptUtil.java
@@ -29,11 +29,12 @@ import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.configuration.XMLConfiguration;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;;
 
 public class EncryptUtil {
 
-    private static final Logger LOGGER = Logger.getLogger(EncryptUtil.class);
+    private static final Logger LOGGER = LogManager.getLogger(EncryptUtil.class);
 
     private static String DB_DEFAULT_DATASOURCE = "db.default.datasource"; //$NON-NLS-1$
 

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/core/MDMConfiguration.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/core/MDMConfiguration.java
@@ -17,7 +17,8 @@ import java.util.Properties;
 
 import org.apache.commons.configuration.ConfigurationConverter;
 import org.apache.commons.configuration.PropertiesConfiguration;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * Handles the mdm.conf file
@@ -67,7 +68,7 @@ public final class MDMConfiguration {
 
     public static final String SCIM_PASSWORD = "scim.password";
 
-    private static final Logger LOGGER = Logger.getLogger(MDMConfiguration.class);
+    private static final Logger LOGGER = LogManager.getLogger(MDMConfiguration.class);
 
     private static MDMConfiguration instance;
 

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/core/MDMXMLUtils.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/core/MDMXMLUtils.java
@@ -28,7 +28,8 @@ import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.talend.mdm.commmon.util.exception.XmlBeanDefinitionException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
@@ -36,7 +37,7 @@ import org.xml.sax.helpers.XMLReaderFactory;
 
 public class MDMXMLUtils {
 
-    private static final Logger LOGGER = Logger.getLogger(MDMXMLUtils.class);
+    private static final Logger LOGGER = LogManager.getLogger(MDMXMLUtils.class);
 
     public static final String FEATURE_DISALLOW_DOCTYPE = "http://apache.org/xml/features/disallow-doctype-decl";
 

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/workbench/ZipToFile.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/workbench/ZipToFile.java
@@ -35,7 +35,7 @@ public class ZipToFile {
 
     public static final int BUFFER = 1024;// buf size
 
-    private static final Logger log = LogManager.getLogger(ZipToFile.class);
+    private static final Logger LOGGER = LogManager.getLogger(ZipToFile.class);
 
     public static void deleteDirectory(File dir) {
         // modified by honghb ,fix bug 21552
@@ -179,7 +179,7 @@ public class ZipToFile {
                         os.write(buf, 0, readLen);
                     }
                 } catch (IOException e) {
-                    log.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 } finally {
                     try {
                         if (is != null) {
@@ -197,7 +197,7 @@ public class ZipToFile {
                 }
             }
         } catch (IOException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             throw e;
         } finally {
             if (zfile != null) {

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/workbench/ZipToFile.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/util/workbench/ZipToFile.java
@@ -25,7 +25,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * DOC aiming class global comment. Detailled comment
@@ -34,7 +35,7 @@ public class ZipToFile {
 
     public static final int BUFFER = 1024;// buf size
 
-    private static final Logger log = Logger.getLogger(ZipToFile.class);
+    private static final Logger log = LogManager.getLogger(ZipToFile.class);
 
     public static void deleteDirectory(File dir) {
         // modified by honghb ,fix bug 21552

--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -1075,6 +1075,11 @@
                 <version>2.9.1</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-1.2-api</artifactId>
+                <version>2.9.1</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
                 <version>1.3.3</version>

--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -945,12 +945,12 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.6.1</version>
+                <version>1.7.25</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
-                <version>1.6.4</version>
+                <version>1.7.25</version>
             </dependency>
             <dependency>
                 <groupId>xml-apis</groupId>
@@ -1065,9 +1065,14 @@
                 <version>5.1.5</version>
             </dependency>
             <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>1.2.17</version>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>2.9.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>2.9.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-fileupload</groupId>

--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -1085,6 +1085,11 @@
                 <version>2.12.1</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>2.12.1</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
                 <version>1.3.3</version>

--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -1076,6 +1076,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-web</artifactId>
+                <version>2.9.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-1.2-api</artifactId>
                 <version>2.9.1</version>
             </dependency>

--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -1067,22 +1067,22 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
-                <version>2.9.1</version>
+                <version>2.12.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
-                <version>2.9.1</version>
+                <version>2.12.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-web</artifactId>
-                <version>2.9.1</version>
+                <version>2.12.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-1.2-api</artifactId>
-                <version>2.9.1</version>
+                <version>2.12.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-fileupload</groupId>

--- a/org.talend.mdm.common/pom.xml
+++ b/org.talend.mdm.common/pom.xml
@@ -70,6 +70,10 @@
             <artifactId>org.eclipse.xsd</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.talend</groupId>
             <artifactId>org.talend.utils</artifactId>
         </dependency>

--- a/org.talend.mdm.common/pom.xml
+++ b/org.talend.mdm.common/pom.xml
@@ -34,8 +34,12 @@
     
     <dependencies>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14697

**What is the current behavior?** (You should also link to an open issue here)

Veracode is reporting a high level CVE against Log4J 1.2.17 as defined in mdm-common/org.talend.mdm.common/pom.xml

**What is the new behavior?**

Updated Log4j from 1.2.17 to 2.12.1, this version can also work with PowerMock/Junit.
And updated log4j.xml to log4j2 format, and changed log4j.properties to log4j2.xml for Junit.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
