### PR TITLE
TMDM-14659 [REST API] Throw UnsupportedOperationException when the foreign key points to an entity with composite key

### DIFF
--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/ComplexTypeMetadataImpl.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/ComplexTypeMetadataImpl.java
@@ -168,6 +168,10 @@ public class ComplexTypeMetadataImpl extends MetadataExtensions implements Compl
         }
         FieldMetadata foundField;
         if (path.indexOf('/') < 0) {
+            // handle CompoundField [id0][id1] from same field's composite key
+            if (path.indexOf('[') >= 0) {
+                path = path.substring(path.indexOf("[") + 1, path.indexOf("]"));
+            }
             foundField = fieldMetadata.get(path); // Shortcut for direct look up for a field (no path involved).
             if (foundField == null) {
                 for (TypeMetadata superType : superTypes) {

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/ComplexTypeMetadataImpl.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/ComplexTypeMetadataImpl.java
@@ -170,7 +170,7 @@ public class ComplexTypeMetadataImpl extends MetadataExtensions implements Compl
         if (path.indexOf('/') < 0) {
             // handle CompoundField [id0][id1] from same field's composite key
             if (path.indexOf('[') >= 0) {
-                path = path.substring(path.indexOf("[") + 1, path.indexOf("]"));
+                path = StringUtils.substringsBetween(path, "[", "]")[0];
             }
             foundField = fieldMetadata.get(path); // Shortcut for direct look up for a field (no path involved).
             if (foundField == null) {

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/CompoundFieldMetadata.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/CompoundFieldMetadata.java
@@ -12,11 +12,14 @@
 package org.talend.mdm.commmon.metadata;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import javax.xml.XMLConstants;
 
+import org.apache.commons.lang.StringUtils;
 import org.talend.mdm.commmon.metadata.validation.ValidationFactory;
 import org.talend.mdm.commmon.metadata.validation.ValidationRule;
 
@@ -27,6 +30,10 @@ public class CompoundFieldMetadata extends MetadataExtensions implements FieldMe
     private boolean isFrozen;
 
     private int cachedHashCode;
+
+    private final Map<Locale, String> localeToLabel = new HashMap<Locale, String>();
+
+    private final Map<Locale, String> localeToDescription = new HashMap<Locale, String>();
 
     public CompoundFieldMetadata(FieldMetadata... fields) {
         this.fields = fields;
@@ -113,11 +120,16 @@ public class CompoundFieldMetadata extends MetadataExtensions implements FieldMe
 
     @Override
     public void registerName(Locale locale, String name) {
+        localeToLabel.put(locale, name);
     }
 
     @Override
     public String getName(Locale locale) {
-        throw new UnsupportedOperationException();
+        String localizedName = localeToLabel.get(locale);
+        if (localizedName == null) {
+            return getName();
+        }
+        return localizedName;
     }
 
     @Override
@@ -201,11 +213,16 @@ public class CompoundFieldMetadata extends MetadataExtensions implements FieldMe
 
     @Override
     public void registerDescription(Locale locale, String description) {
+        localeToDescription.put(locale, description);
     }
 
     @Override
     public String getDescription(Locale locale) {
-        throw new UnsupportedOperationException();
+        String localizedDescription = localeToDescription.get(locale);
+        if (localizedDescription == null) {
+            return StringUtils.EMPTY;
+        }
+        return localizedDescription;
     }
 
     @Override

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/CompoundFieldMetadata.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/CompoundFieldMetadata.java
@@ -37,7 +37,11 @@ public class CompoundFieldMetadata extends MetadataExtensions implements FieldMe
     }
 
     public String getName() {
-        throw new UnsupportedOperationException();
+        String name = ""; //$NON-NLS-1$
+        for (FieldMetadata field : fields) {
+            name += "[" + field.getName() + "]"; //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return name;
     }
 
     public boolean isKey() {

--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/CompoundFieldMetadata.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/CompoundFieldMetadata.java
@@ -44,7 +44,7 @@ public class CompoundFieldMetadata extends MetadataExtensions implements FieldMe
     }
 
     public String getName() {
-        String name = ""; //$NON-NLS-1$
+        String name = StringUtils.EMPTY;
         for (FieldMetadata field : fields) {
             name += "[" + field.getName() + "]"; //$NON-NLS-1$ //$NON-NLS-2$
         }


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14659

**What is the current behavior?** (You should also link to an open issue here)

Previous version didn't support composite key in Join of MDM query, details can be found from Dev Design in Jira:
https://jira.talendforge.org/browse/TMDM-14659?focusedCommentId=805994&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-805994

**What is the new behavior?**

Added support for composite key in Join of MDM query.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
