### PR TITLE
TMDM-14740 Remove Log4j 1 in pom of DA proxy once TUP-27949 is done

### DIFF
--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -643,7 +643,7 @@
             <dependency>
                 <groupId>org.talend</groupId>
                 <artifactId>org.talend.utils</artifactId>
-                <version>7.3.1</version>
+                <version>7.4.1-SNAPSHOT</version>
                 <exclusions>
                     <exclusion>
                         <groupId>log4j</groupId>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14740

**What is the current behavior?** (You should also link to an open issue here)

Current version of org.talend.utils in tmdm-common is 7.3.1, which used Log4j 1 directly in the source code, as DA also used tmdm-common, so DA pom file have to import Log4j 1.

**What is the new behavior?**

Updated to new version of org.talend.utils which used slf4j, in MDM server or DA, we don't need to add Log4j 1 library explicitly.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
