### PR TITLE
TMDM-12515 Can't prepare DB if field's type is MULTI_LINGUAL or boolean and has default value

### DIFF
--- a/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/annotation/DefaultValueRuleProcessor.java
+++ b/main/plugins/org.talend.mdm.commmon/src/main/java/org/talend/mdm/commmon/metadata/annotation/DefaultValueRuleProcessor.java
@@ -29,7 +29,7 @@ public class DefaultValueRuleProcessor implements XmlSchemaAnnotationProcessor {
                 String source = appInfo.getAttribute("source"); //$NON-NLS-1$
 
                 if ("X_Default_Value_Rule".equals(source)) { //$NON-NLS-1$
-                    if (isValue(appInfo.getTextContent())) {
+                    if (isValue(appInfo.getTextContent().trim())) {
                         state.setDefaultValueRule(appInfo.getTextContent());
                     }
                 }
@@ -41,7 +41,7 @@ public class DefaultValueRuleProcessor implements XmlSchemaAnnotationProcessor {
         boolean isValue = false;
 
         if (StringUtils.isNotBlank(text)) {
-            if (StringUtils.startsWith(text, "\"") && StringUtils.endsWith(text, "\"")) { //$NON-NLS-1$ //$NON-NLS-2$
+            if (text.matches("('.*?'|\".*?\")")) { //$NON-NLS-1$
                 isValue = true;
             } else if (NumberUtils.isNumber(text)) {
                 isValue = true;


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)



**What is the new behavior?**
Cherry-pick from maintenance/6.5
TMDM-12515 Can't prepare DB if field's type is MULTI_LINGUAL or boolean and has default value 


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
