### PR TITLE
TMDM-14946 High Memory used by MDM Tomcat JVM when calling REST API PUT with "as of "

### DIFF
--- a/org.talend.mdm.base/pom.xml
+++ b/org.talend.mdm.base/pom.xml
@@ -956,7 +956,6 @@
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
                 <version>1.4.187</version>
-                <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>net.sourceforge.jtds</groupId>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14946
**What is the current behavior?** (You should also link to an open issue here)
High Memory used by MDM Tomcat JVM when calling REST API PUT with "as of "


**What is the new behavior?**
The memory is OK when calling same REST API PUT with "as of"


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
